### PR TITLE
[ci] Upload binaries to existing release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 on:
-  [push, pull_request]
+  push:
+    branches: ['**']
+  pull_request:
+  release:
+    types: published
 
 env:
   PACKAGE: mbedtls
@@ -48,16 +52,15 @@ jobs:
 
   release:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v7
 
       - run: |
-          gh release create ${{ github.ref_name }} \
-            --verify-tag \
-            --title ${{ github.ref_name }} \
+          gh release upload ${{ github.ref_name }} \
+            --clobber \
             artifact-*/*.tar.xz
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cygport mingw64-x86_64.cygport all
 To test the package, you can unzip it into the root directory:
 
 ```sh
-tar -C / -xvf mingw64-x86_64-mbedtls-*-1.noarch/dist/mingw64-x86_64-mbedtls/mingw64-x86_64-mbedtls-*-1.tar.xz
+tar -C / -xvf mingw64-x86_64-mbedtls-*-1.noarch/dist/mingw64-x86_64-mbedtls/mingw64-x86_64-mbedtls-*-1-noarch.tar.xz
 ```
 
 See [cygwin documentation](https://cygwin.com/packaging-contributors-guide.html) for more information.


### PR DESCRIPTION
Instead of creating a new release, the workflow now runs after a release has been published and uploads the binaries to it.